### PR TITLE
Updated DB schemas to include a generic post template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = true
+indent_style = tab
+
+[{*.yml,*.json}]
+indent_style = space
+indent_size = 2

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var sass = require('gulp-sass');
 
 
 var paths = {
-	'src':['./models/**/*.js','./routes/**/*.js', 'keystone.js', 'package.json']
+	'src':['./models/**/*.js','./routes/**/*.js', 'server.js', 'package.json']
 
 ,
 	'style': {
@@ -42,7 +42,7 @@ gulp.task('sass', function(){
 });
 
 
-gulp.task('runKeystone', shell.task('node keystone.js'));
+gulp.task('runKeystone', shell.task('node server.js'));
 gulp.task('watch', [
 
   'watch:sass',

--- a/models/TextPost.js
+++ b/models/TextPost.js
@@ -1,0 +1,71 @@
+'use strict';
+const keystone = require('keystone');
+const moment = require('moment');
+
+// Docs: http://keystonejs.com/docs/database/#fieldtypes
+const Types = keystone.Field.Types;
+
+// Docs: http://keystonejs.com/docs/database/#lists-options
+const options = {
+	autokey: { path: 'slug', from: 'title', unique: true },
+	map: { name: 'title' },
+	singular: 'Post',
+	plural: 'Posts',
+	sortable: true,
+	defaultSort: '-draftedAt',
+	drilldown: 'author'
+};
+
+let TextPost = new keystone.List('TextPost', options);
+
+TextPost.add({
+	title: { type: Types.Text, required: true },
+	author: { type: Types.Relationship, ref: 'User', required: true,
+		initial: true },
+	isPublished: { type: Types.Boolean, default: false },
+	draftedAt: { type: Types.Datetime, default: Date.now, noedit: true },
+	publishedAt: { type: Types.Datetime, noedit: true },
+	lastEditedAt: { type: Types.Datetime, noedit: true },
+	editCount: { type: Types.Number, default: 0, noedit: true },
+	textContent: { type: Types.Html, wysiwyg: true, note: 'Can be expanded' },
+	silentEdit: { type: Types.Boolean, default: false,
+		note: 'Use to edit a post from the admin UI without \
+			changing the edit counter. Be sure to set to false again after \
+			you finish your edit.' }
+
+})
+
+/* Set up the Mongoose schema
+	API Docs: http://mongoosejs.com/docs/api.html
+	Docs on Pre and Post: http://mongoosejs.com/docs/middleware.html */
+TextPost.schema.methods.wasEdited = function () {
+	return this.editCount > 0;
+}
+
+/* Set the published date when the post first gets published 
+	or set the edit date and the edit counter */
+TextPost.schema.pre('save', function (next) {
+	if (this.isModified('isPublished') && this.isPublished &&
+		!this.publishedAt) {
+		this.publishedAt = moment();
+	} else if (this.isModified('textContent') && this.isPublished && 
+		this.publishedAt && !this.silentEdit) {
+		this.lastEditedAt = moment();
+		this.editCount += 1;
+	}
+
+	next(); // Everyone loves callback hell
+});
+
+TextPost.schema.post('save', function (next) {
+	if (this.silentEdit) {
+		this.silentEdit = false;
+		console.log('An admin attempted a silent edit at ' + new Date() +
+			'.');
+	}
+})
+
+TextPost.defaultColumns = 'title, author, isPublished,' +
+	' draftedAt, publishedAt';
+
+TextPost.register();

--- a/models/User.js
+++ b/models/User.js
@@ -1,30 +1,31 @@
-var keystone = require('keystone');
-var Types = keystone.Field.Types;
+'use strict';
+const keystone = require('keystone');
 
-/**
- * User Model
- * ==========
- */
+// Docs: http://keystonejs.com/docs/database/#fieldtypes
+const Types = keystone.Field.Types;
 
-var User = new keystone.List('User');
+// Default user accounts... might be good enough, maybe worth changing.
+let User = new keystone.List('User');
 
 User.add({
 	name: { type: Types.Name, required: true, index: true },
 	email: { type: Types.Email, initial: true, required: true, index: true },
+	// Docs: Passwords are automatically encrypted
 	password: { type: Types.Password, initial: true, required: true }
 }, 'Permissions', {
 	isAdmin: { type: Boolean, label: 'Can access Keystone', index: true }
 });
 
-// Provide access to Keystone
-User.schema.virtual('canAccessKeystone').get(function() {
+// Provide access to the Keystone admin pane if isAdmin is true
+// Docs: This is also how you add public functions to the DB schema.
+User.schema.virtual('canAccessKeystone').get(function () {
 	return this.isAdmin;
 });
 
 
-/**
- * Registration
- */
-
+/* When someone is browsing the admin pane, they'll see the DB columns
+	in this order. */
 User.defaultColumns = 'name, email, isAdmin';
+
+// Docs: If you don't do this, the Model won't be available to Keystone.
 User.register();

--- a/server.js
+++ b/server.js
@@ -57,7 +57,8 @@ keystone.set('routes', require('./routes'));
 
 // This sets up the navbar in the admin UI page.
 keystone.set('nav', {
-	'users': 'users'
+	'users': 'users',
+	'posts': 'text-posts'
 });
 
 // Initialize the web server. It will also listen for the events specified.
@@ -65,14 +66,12 @@ keystone.set('nav', {
 keystone.start({
 
 	onHttpServerCreated: function () {
-		console.log('Server was started in non-secure mode listening to ' +
-			keystone.get('port'));
+		console.log('Server was started in non-secure mode!');
 	}
 
 	/* TODO: Remove this comment when HTTPS is ready.
 	onHttpsServerCreated: function () {
-		console.log('Server is HTTPS secured and listening to port ' +
-			keystone.get('ssl port') + '.');
+		console.log('Server is HTTPS secured.);
 	} */
 
 });


### PR DESCRIPTION
This is the first step in getting a working model for posts. In the future, there will be better methods and functions to get information from the post. If you're going to work with this, use the standard mongoose functions as described [here.](http://keystonejs.com/docs/database/#lists-querying)
