### PR TITLE
Playlist model v0.1, supports JSON or Mongoose trickery

### DIFF
--- a/models/Playlist.js
+++ b/models/Playlist.js
@@ -1,0 +1,65 @@
+'use strict';
+const keystone = require('keystone');
+
+// Docs: http://keystonejs.com/docs/database/#fieldtypes
+const Types = keystone.Field.Types;
+
+// Docs: http://keystonejs.com/docs/database/#lists-options
+const options = {
+	autokey: { path: 'slug', from: 'title', unique: true },
+	map: { name: 'title' },
+	singular: 'Playlist',
+	plural: 'Playlists',
+	sortable: true,
+	defaultSort: '-date',
+	drilldown: 'author'
+};
+
+const Playlist = new keystone.List('Playlist', options);
+
+/* On Create Playlist: Add title, author, date if not today.
+	Description is optional. Set isPublished and isPromoted if necessary.
+	You should treat "tracks" below as if it were in Playlist.add and
+	the constructor works like you'd expect. */
+Playlist.add({
+	title: { type: Types.Text, required: true },
+	author: { type: Types.Relationship, ref: 'User', required: true,
+		initial: true, noedit: true },
+	date: { type: Types.Date, required: true, default: Date.now },
+	description: { type: Types.Html, default: '' }, //Not required currently
+	isPublished: { type: Types.Boolean, default: false },
+	isPromoted: { type: Types.Boolean, default: false },
+	/* Docs: JSON.stringify objects that follow this standard:
+		{ artist: String, album: String, title: String, label: String, 
+		link: String, weight: Number } (we can always add more if needed).
+		JSON.deserialize should be used upon getting the string array,
+		expect to get objects from it (naturally). */
+	// !!! Do not set to required/initial, causes undefined behavior !!!
+	serializedTracks: { type: Types.TextArray, default: [],
+		note: 'Serialized JSON, deserialize to use.'}
+});
+
+// Treat this as if it were part of the Playlist.add above!
+/* Appropriate usage:
+	list = new Playlist.model.add({ // stuff });
+	list.add(tracks: [{
+		artist: 'str',
+		album: 'str',
+		//etc
+	}]);
+*/
+Playlist.schema.add({
+	tracks: [{
+		artist: String,
+		album: String,
+		title: String,
+		label: String,
+		link: String,
+		weight: Number
+	}] // Bypasses Keystone, it doesn't support this.
+});
+
+Playlist.defaultColumns = 'title, author, date, description,' +
+	' isPublished, isPromoted, serializedTracks';
+
+Playlist.register();

--- a/models/TextPost.js
+++ b/models/TextPost.js
@@ -18,6 +18,9 @@ const options = {
 
 let TextPost = new keystone.List('TextPost', options);
 
+/* On Create Post: Add title, author, textContent. Set isPublished if
+	the post is not a draft. Everything else should not be touched and
+	will be set automatically! */
 TextPost.add({
 	title: { type: Types.Text, required: true },
 	author: { type: Types.Relationship, ref: 'User', required: true,
@@ -27,7 +30,8 @@ TextPost.add({
 	publishedAt: { type: Types.Datetime, noedit: true },
 	lastEditedAt: { type: Types.Datetime, noedit: true },
 	editCount: { type: Types.Number, default: 0, noedit: true },
-	textContent: { type: Types.Html, required: true, initial: true, wysiwyg: true, note: 'Can be expanded' },
+	textContent: { type: Types.Html, required: true, initial: true, 
+		wysiwyg: true, note: 'Can be expanded' },
 	silentEdit: { type: Types.Boolean, default: false,
 		note: 'Use to edit a post from the admin UI without \
 			changing the edit counter. Be sure to set to false again after \

--- a/models/User.js
+++ b/models/User.js
@@ -4,8 +4,14 @@ const keystone = require('keystone');
 // Docs: http://keystonejs.com/docs/database/#fieldtypes
 const Types = keystone.Field.Types;
 
+const options = {
+	autokey: { path: 'slug', from: 'name', unique: true },
+	singular: 'User',
+	plural: 'Users',
+};
+
 // Default user accounts... might be good enough, maybe worth changing.
-let User = new keystone.List('User');
+let User = new keystone.List('User', options);
 
 User.add({
 	name: { type: Types.Name, required: true, index: true },

--- a/routes/views/index.js
+++ b/routes/views/index.js
@@ -1,10 +1,11 @@
-var keystone = require('keystone');
-var TextPost = keystone.list('TextPost');
+'use strict';
+const keystone = require('keystone');
+const TextPost = keystone.list('TextPost');
 
-exports = module.exports = function(req, res) {
+exports = module.exports = function (req, res) {
 	
-	var view = new keystone.View(req, res);
-	var locals = res.locals;
+	let view = new keystone.View(req, res);
+	let locals = res.locals;
 	
 	// locals.section is used to set the currently selected
 	// item in the header navigation.
@@ -12,22 +13,24 @@ exports = module.exports = function(req, res) {
 	
 	// Load posts
 	view.on('init', function (next) {
-		TextPost.model.find()
-			.populate('author', 'name')
-			.exec(function (err, posts) {
-			if (err) return res.err(err);
-			locals.posts = posts;
+		TextPost.paginate({
+			page: req.query.page || 1,
+			perPage: 10
+		}).where('isPublished')
+		.sort('-publishedAt')
+		.populate('author', 'name')
+		.exec(function (err, posts) {
+			locals.posts = posts.results;
 			next();
 		});
 	});
 	
 	// Accept form post submit
-	view.on('post', { action: 'create-post' }, function(next) {
+	view.on('post', { action: 'create-post' }, function (next) {
 
 		// handle form
-		var newPost = new TextPost.model({
-				author: locals.user.id,
-				publishedDate: new Date()
+		let newPost = new TextPost.model({
+				author: locals.user.id
 			}),
 
 			updater = newPost.getUpdateHandler(req, res, {
@@ -36,14 +39,14 @@ exports = module.exports = function(req, res) {
 
 		// automatically pubish posts by admin users
 		if (locals.user.isAdmin) {
-			newPost.state = 'published';
+			newPost.isPublished = true;
 		}
 
 		updater.process(req.body, {
 			flashErrors: true,
 			logErrors: true,
 			fields: 'title, textContent'
-		}, function(err) {
+		}, function (err) {
 			if (err) {
 				locals.validationErrors = err.errors;
 				next();
@@ -62,22 +65,25 @@ exports = module.exports = function(req, res) {
 			return next();
 		}
 		TextPost.model.findOne({
-				_id: req.query.post
+				slug: req.query.post
 			})
 			.exec(function (err, post) {
 				if (err) {
 					if (err.name === 'CastError') {
-						req.flash('error', 'The post ' + req.query.post + ' could not be found.');
+						req.flash('error', 'The post ' + req.query.post + 
+							' could not be found.');
 						return next();
 					}
 					return res.err(err);
 				}
 				if (!post) {
-					req.flash('error', 'The post ' + req.query.post + ' could not be found.');
+					req.flash('error', 'The post ' + req.query.post + 
+						' could not be found.');
 					return next();
 				}
 				if (post.author != req.user.id) {
-					req.flash('error', 'Sorry, you must be the author of a post to delete it.');
+					req.flash('error', 'Sorry, you must be the author' + 
+						' of a post to delete it.');
 					return next();
 				}
 				post.remove(function (err) {

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-// Keystone API Docs: https://github.com/keystonejs/keystone/wiki/Keystone-API
+// Keystone Docs: https://github.com/keystonejs/keystone/wiki/Keystone-API
 
 // Simulate config options from your production environment by
 // customising the .env file in your project's root folder.

--- a/templates/mixins/posts.jade
+++ b/templates/mixins/posts.jade
@@ -29,7 +29,7 @@ mixin show-post(post)
 					p!=post.textContent.replace(/\n/g, '<br>')
 					if user && user.id === post.author.id
 						|  &middot; 
-						a(href='?remove=post&post=' + post.id, title='Delete this post', rel='tooltip', data-placement='left').post-delete.js-delete-confirm Delete
+						a(href='?remove=post&post=' + post.slug, title='Delete this post', rel='tooltip', data-placement='left').post-delete.js-delete-confirm Delete
 
 mixin show-posts(posts)
 	if posts.length


### PR DESCRIPTION
Be sure to be careful how you pass the tracks in. You can either pass an array of serialized JSON objects in the "serializedTracks" field or you can pass an array of regular objects into the "tracks" field using some Mongoose functions (read Playlist.js, it's undocumented but will work). The objects should follow the same format as on the current WUSB site. 
In the future we'll decide which one to use exclusively. Looking for feedback from @kenfehling -- when you make the "Create Playlist" page tell me which one you prefer to use.

Also, combined #8 into this one so that they can be merged at the same time. As such, I've closed #8.
