### PR TITLE
Add Program schema with one-many relationships to User and Playlist

### DIFF
--- a/models/Program.js
+++ b/models/Program.js
@@ -1,0 +1,34 @@
+'use strict';
+const keystone = require('keystone');
+
+// Docs: http://keystonejs.com/docs/database/#fieldtypes
+const Types = keystone.Field.Types;
+
+// Docs: http://keystonejs.com/docs/database/#lists-options
+const options = {
+	autokey: { path: 'slug', from: 'title', unique: true },
+	map: { name: 'title' },
+	singular: 'Program',
+	plural: 'Programs',
+	sortable: true,
+	defaultSort: '-title',
+	drilldown: 'djs playlists'
+};
+
+const Program = new keystone.List('Program', options);
+
+Program.add({
+	title: { type: Types.Text, required: true },
+	djs: { type: Types.Relationship, ref: 'User', many: true, 
+		required: true, initial: true },
+	schedule: { type: Types.Date, required: true, default: Date.now },
+	isBiweekly: { type: Types.Boolean, default: false },
+	description: { type: Types.Text, default: '', note: 'Optional' },
+	playlists: { type: Types.Relationship, ref: 'Playlist', many: true },
+	genre: { type: Types.Text, required: true, initial: true }
+});
+
+Program.defaultColumns = 'title, djs, genre, schedule, description, ' +
+	'isBiweekly, playlists';
+
+Program.register();

--- a/models/User.js
+++ b/models/User.js
@@ -17,7 +17,8 @@ User.add({
 	name: { type: Types.Name, required: true, index: true },
 	email: { type: Types.Email, initial: true, required: true, index: true },
 	// Docs: Passwords are automatically encrypted
-	password: { type: Types.Password, initial: true, required: true }
+	password: { type: Types.Password, initial: true, required: true },
+	isConfirmed: { type: Boolean, default: false }
 }, 'Permissions', {
 	isAdmin: { type: Boolean, label: 'Can access Keystone', index: true }
 });

--- a/server.js
+++ b/server.js
@@ -20,8 +20,8 @@ function getDbUri() {
 		return 'mongodb://localhost:27017/wusb_test';
 	}
 	else {
-		throw new Error("NODE_ENV must be production, development, or test. " +
-						"Found: " + env);
+		throw new Error('NODE_ENV must be production, development, ' + 
+			'or test. Found: ' + env);
 	}
 }
 
@@ -78,7 +78,9 @@ keystone.set('routes', require('./routes'));
 // This sets up the navbar in the admin UI page.
 keystone.set('nav', {
 	'users': 'users',
-	'posts': 'text-posts'
+	'posts': 'text-posts',
+	'programs': 'programs',
+	'playlists': 'playlists'
 });
 
 // Initialize the web server. It will also listen for the events specified.


### PR DESCRIPTION
Be careful modifying the Program's one-to-many relationships. Use $push instead of $set so you don't delete what was there. Look in the pre save hook of Program.js for an example of this.

Should we be able to edit the Program a Playlist is associated with? Right now I chose not to include that. It shouldn't be too difficult to include in the future.
