### PR TITLE
Updates now export functions even if NODE_ENV is not "development"

### DIFF
--- a/updates/0.0.2-posts.js
+++ b/updates/0.0.2-posts.js
@@ -36,4 +36,10 @@ if (env === 'development') {
 			}
 		});
 	};
+} else {
+	exports = module.exports = done => {
+		console.log('Patch 0.0.2 is not applicable in production or ' +
+			'testing');
+		done();
+	}
 }

--- a/updates/0.0.3-programs.js
+++ b/updates/0.0.3-programs.js
@@ -38,4 +38,10 @@ if (env === 'development') {
 			}
 		});
 	};
+} else {
+	exports = module.exports = done => {
+		console.log('Patch 0.0.3 is not applicable in production or ' +
+			'testing.');
+		done();
+	}
 }

--- a/updates/0.0.4-playlists.js
+++ b/updates/0.0.4-playlists.js
@@ -74,4 +74,10 @@ if (env === 'development') {
 			}
 		});
 	};
+} else {
+	exports = module.exports = done => {
+		console.log('Patch 0.0.4 is not applicable in production or ' +
+			'testing.');
+		done();
+	}
 }


### PR DESCRIPTION
Fixes an error that occurs if you set NODE_ENV to anything other than development.
