### PR TITLE
Program schema update, bounds checking on program time

### DIFF
--- a/models/Playlist.js
+++ b/models/Playlist.js
@@ -32,8 +32,9 @@ Playlist.add({
 	isPublished: { type: Types.Boolean, default: false },
 	isPromoted: { type: Types.Boolean, default: false },
 	/* Docs: JSON.stringify objects that follow this standard:
-		{ artist: String, album: String, title: String, label: String, 
-		link: String, weight: Number } (we can always add more if needed).
+		{ isNew: Boolean, artist: String, album: String, title: String, 
+			label: String, link: String, weight: Number } 
+		(we can always add more if needed)
 		JSON.deserialize should be used upon getting the string array,
 		expect to get objects from it (naturally). */
 	// !!! Do not set to required/initial, causes undefined behavior !!!


### PR DESCRIPTION
The proper way to use the new fields:
`day`: 0 is Sunday, 6 is Saturday. The user should probably have a pull-down menu.
`startTime`: 0 is 12:00 AM, 2399 is 11:59 PM. Either have pulldown menus or use front-end verification with text entry boxes. If we go this route I'll update the presave hook to do backend verification.
`endTime`: Same.
`isBiweekly`: Just what it says.
`biweeklyState`: `true` if the playlist plays on the first week of the year. `false` if not. `null` if `isBiweekly` is false (this is already enforced by the presave hook, don't worry about this).
