### PR TITLE
Show the live program, prepare to add links to user profile

### DIFF
--- a/models/Program.js
+++ b/models/Program.js
@@ -40,7 +40,7 @@ Program.schema.pre('save', function (next) {
 		(this.biweeklyState === null)) {
 		this.biweekylState = false;
 	} else if (this.isModified('isBiweekly') && !this.isBiweekly) {
-		this.biWeeklystate = null;
+		this.bieeklyState = null;
 	}
 	// Bounds checking starts here
 	if (this.isBiweekly) {
@@ -146,6 +146,19 @@ function daysSinceBeginningOfYear(date) {
 	return Math.floor(diff / millisPerDay);
 }
 
+/* Uses daysSinceBeginningOfYear to get this week's 
+	biweekly state. */
+function getCurrentBiweeklyState() {
+	return Math.floor(Math.floor(daysSinceBeginningOfYear() / 7) / 2) == 0;
+}
+
+/* Uses JS Date object functions to get the time
+	in the format expected by the DB */
+function getTime() {
+	const now = new Date();
+	return (now.getHours() * 100) + now.getMinutes()
+}
+
 Program.schema.virtual('startTimeString').get(function() {
 	return toTimeString(this.startTime);
 });
@@ -168,8 +181,7 @@ Program.schema.virtual('nextAirDateMMDDYY').get(function() {
 Program.schema.virtual('isLiveNow').get(function () {
 	// Check biweekly first, then do a general bounds check.
 	if (this.isBiweekly) {
-		const curWeek = Math.floor(Math.floor(daysSinceBeginningOfYear() / 7) / 2);
-		const state = curWeek == 0;
+		const state = getCurrentBiweeklyState();
 		if (this.biweeklyState != state) {
 			return false;
 		}
@@ -177,13 +189,28 @@ Program.schema.virtual('isLiveNow').get(function () {
 	// General bounds check
 	const now = new Date();
 	if (this.day == now.getDay()) {
-		const time = (now.getHours() * 100) + now.getMinutes();
+		const time = getTime();
 		if (this.startTime < time && this.endTime > time) {
 			return true;
 		}
 	}
 	return false; // No sense in repeating this
 });
+
+/* Call this with a callback expecting an error object
+	and a program. If program is null there is no live
+	program at the moment. */
+Program.schema.statics.getLiveProgram = function (next) {
+	const state = getCurrentBiweeklyState();
+	const now = new Date();
+	const time = getTime();
+	this.findOne({ 
+		day: now.getDay(),
+		startTime: {$lte: time},
+		endTime: {$gte: time},
+		biweeklyState: {$ne: !state} //capture undefined+null
+	}).populate(['djs']).exec(next);
+};
 
 Program.schema.statics.getTimeSlots = function() {
 	return _.map(_.flatten(_.map(_.range(24), h => [h*100, h*100+30])), num => ({

--- a/routes/index.js
+++ b/routes/index.js
@@ -60,6 +60,7 @@ exports = module.exports = app => {
 	app.get('/program/:slug/edit', middleware.requireAdmin, routes.views.edit_program);
 	app.post('/program', middleware.requireAdmin, routes.post.post_program);
 	app.post('/program/:slug/edit', middleware.requireAdmin, routes.post.post_program);
+	app.get('/live', routes.views.live);
 	
 	// API
 	app.get('/api/users', middleware.loadUsers, routes.api.users);

--- a/routes/views/live.js
+++ b/routes/views/live.js
@@ -1,0 +1,21 @@
+'use strict';
+const keystone = require('keystone');
+const Program = keystone.list('Program');
+
+exports = module.exports = (req, res) => {
+	const view = new keystone.View(req, res);
+	const locals = res.locals;
+	locals.section = 'programs';
+
+	// Load programs
+	view.on('init', next => {
+		Program.model.getLiveProgram(function (err, prg) {
+			keystone.populateRelated(prg, 'djs', (err) => {
+				locals.prg = prg;
+				next();
+			});
+		});
+	});
+
+	view.render('live');
+};

--- a/templates/mixins/programs.jade
+++ b/templates/mixins/programs.jade
@@ -99,3 +99,14 @@ mixin post-program(editing)
 			//- Submit
 			.form-group
 				button(type='submit', data-loading-text="Changing...").btn.btn-lg.btn-primary.btn-block Save program
+
+mixin live-program(prg)
+	if prg
+		h2!='Title: ' + prg.title
+		p!='Genre: ' + prg.genre
+		- var names = 'Djs:'
+		for dj in prg.djs
+			- names += ' ' + dj.name.first + ' ' + dj.name.last
+		p!=names
+	else
+		p!='No program right now.'

--- a/templates/views/live.jade
+++ b/templates/views/live.jade
@@ -1,0 +1,6 @@
+extends ../layouts/default
+include ../mixins/programs
+
+block content
+	.container: .jumbotron
+		+live-program(prg)


### PR DESCRIPTION
There don't appear to be user profiles to link to yet, but as long as we use the slug to determine where they are, it should be easy enough to modify this to do that. Currently, the live program stuff is constrained to _urlbase.here_/live and once we figure out how to style it we can move it into the default.jade

Also, once again this has all of Ken's commits. It's probably because I'm pulling his commits to work off of so I have the most "up-to-date" base branch and they aren't merged yet. If they don't go away then I can rebase like before (basically, I create a new local branch off master, copy my one commit's diff into it, then force push).
